### PR TITLE
Add requirements.txt for virtualenv installations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# `basemap` is too big to be hosted on PyPI:
+# https://github.com/matplotlib/basemap/issues/198
+https://github.com/matplotlib/basemap/archive/v1.0.7rel.tar.gz
+matplotlib
+numpy
+# indirect dependency: `basemap` requires `PIL`
+pillow
+pygeoip
+requests


### PR DESCRIPTION
Hopefully closes #12.

`basemap` must be installed directly from .tar.gz, since it's too big to be on PyPI.

`basemap` v1.1.0 didn't work for me (compilation error).

`pillow` (actually `PIL`) is an indirect dependency (via `basemap`).

For reference, my current `pip freeze` in the `virtualenv` is:

``` python
basemap==1.0.7
certifi==2018.4.16
chardet==3.0.4
cycler==0.10.0
idna==2.7
kiwisolver==1.0.1
matplotlib==2.2.2
numpy==1.14.5
Pillow==5.1.0
pygeoip==0.3.2
pyparsing==2.2.0
pyproj==1.9.5.1
pyshp==1.2.12
python-dateutil==2.7.3
pytz==2018.4
requests==2.19.0
six==1.11.0
urllib3==1.23
```