### PR TITLE
Upgrade from GeoLite Legacy to GeoLite2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Python script to show where IP addresses are coming from by plotting them on a
 * [numpy](http://www.numpy.org/)
 * [matplotlib](http://matplotlib.org/)
 * [Basemap](http://matplotlib.org/basemap/)
-* [pygeoip](https://pypi.python.org/pypi/pygeoip)
+* [GeoIP2-python](https://github.com/maxmind/GeoIP2-python)
 
 PyGeoIpMap can be installed along with its dependencies easily on Fedora Linux with the following command:
 
@@ -79,7 +79,7 @@ In that example above, the program will use data available from
 
 ### Using a MaxMind offline database (Recommended)
 
-Local [MaxMind](http://dev.maxmind.com/geoip/legacy/geolite/) database files can be used with the MaxMind [GeoIP](https://github.com/maxmind/geoip-api-python) library with the `--service` option:
+Local [MaxMind](https://dev.maxmind.com/geoip/geoip2/geolite2/) database files can be used with the MaxMind [GeoIP](https://github.com/maxmind/GeoIP2-python) library with the `--service` option:
 
 ```bash
 python3 pygeoipmap.py -i /tmp/ip.txt --service m --db /path/to/GeoLiteCity.dat

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ In that example above, the program will use data available from
 Local [MaxMind](https://dev.maxmind.com/geoip/geoip2/geolite2/) database files can be used with the MaxMind [GeoIP](https://github.com/maxmind/GeoIP2-python) library with the `--service` option:
 
 ```bash
-python3 pygeoipmap.py -i /tmp/ip.txt --service m --db /path/to/GeoLiteCity.dat
+python3 pygeoipmap.py -i /tmp/ip.txt --service m --db /path/to/GeoLite2-City.mmdb
 ```
 
 You can download and unzip a copy of the latest MaxMind database as follows:
 
 ```bash
-wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.xz && xz -d GeoLiteCity.dat.xz
+wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz && tar -xzvf GeoLite2-City.tar.gz
 ```
 
 ### Specifying a region for the plot

--- a/pygeoipmap.py
+++ b/pygeoipmap.py
@@ -12,8 +12,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from mpl_toolkits.basemap import Basemap
-import pygeoip
-
+import geoip2.database
 
 def get_ip(ip_file):
     """
@@ -48,14 +47,14 @@ def geoip_lat_lon(gi, ip_list=[], lats=[], lons=[]):
     print("Processing {} IPs...".format(len(ip_list)))
     for ip in ip_list:
         try:
-            r = gi.record_by_addr(ip)
+            r = gi.city(ip)
         except Exception:
             print("Unable to locate IP: %s" % ip)
             continue
         if r is not None:
-            print("%s {country_code} {latitude}, {longitude}".format(**r) % ip)
-            lats.append(r['latitude'])
-            lons.append(r['longitude'])
+            #print("%s {country_code} {latitude}, {longitude}".format(**r) % ip)
+            lats.append(r.location.latitude)
+            lons.append(r.location.longitude)
     return lats, lons
 
 
@@ -118,7 +117,7 @@ def main():
     if args.format == 'ip':
         ip_list = get_ip(args.input)
         if args.service == 'm':
-            gi = pygeoip.GeoIP(args.db)
+            gi = geoip2.database.Reader(args.db)
             lats, lons = geoip_lat_lon(gi, ip_list)
         else:  # default service
             if args.apikey:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy
 pillow
 pygeoip
 requests
+GeoIP2-python


### PR DESCRIPTION
GeoLite was discontinued on january 2nd 2019. I removed legacy support and added support for GeoLite2 databases by using GeoIP2-python. This also solves https://github.com/pieqq/PyGeoIpMap/issues/9 .