### PR TITLE
sometimes an entry is missing lat/lon

### DIFF
--- a/pygeoipmap.py
+++ b/pygeoipmap.py
@@ -51,10 +51,12 @@ def geoip_lat_lon(gi, ip_list=[], lats=[], lons=[]):
         except Exception:
             print("Unable to locate IP: %s" % ip)
             continue
-        if r is not None:
-            #print("%s {country_code} {latitude}, {longitude}".format(**r) % ip)
-            lats.append(r.location.latitude)
-            lons.append(r.location.longitude)
+        if r is None or r.location.latitude is None or r.location.longitude is None:
+            print("Unable to find lat/long for IP: %s" % ip)
+            continue
+        #print("%s {country_code} {latitude}, {longitude}".format(**r) % ip)
+        lats.append(r.location.latitude)
+        lons.append(r.location.longitude)
     return lats, lons
 
 


### PR DESCRIPTION
When it is, geoip_lat_lon should skip that ip.  Currently, if your `ip_list` contains an IP which has an entry, but that entry lacks a lat/lon, it crashes with the following stack trace:

```
$ ./pygeoipmap.py -i unique-ips-fixed.txt --service m -db GeoLite2-City.mmdb -o /var/www/2019-09-20-all-viewers-new.png 
Processing 17257 IPs...
Generating map and saving it to /var/www/2019-09-20-all-viewers-new.png
Traceback (most recent call last):
  File "./pygeoipmap.py", line 138, in <module>
    main()
  File "./pygeoipmap.py", line 134, in main
    generate_map(output, lats, lons, wesn=args.extents)
  File "./pygeoipmap.py", line 99, in generate_map
    m.scatter(x, y, s=1, color='#ffff00', marker='o', alpha=0.3)
  File "/usr/lib/pymodules/python2.7/mpl_toolkits/basemap/__init__.py", line 2900, in scatter
    ret =  ax.scatter(*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/matplotlib/axes.py", line 5876, in scatter
    self.add_collection(collection)
  File "/usr/lib/pymodules/python2.7/matplotlib/axes.py", line 1445, in add_collection
    self.update_datalim(collection.get_datalim(self.transData))
  File "/usr/lib/pymodules/python2.7/matplotlib/collections.py", line 160, in get_datalim
    offsets = transOffset.transform_non_affine(offsets)
  File "/usr/lib/pymodules/python2.7/matplotlib/transforms.py", line 1925, in transform_non_affine
    self._a.transform(points))
  File "/usr/lib/pymodules/python2.7/matplotlib/transforms.py", line 1415, in transform
    return affine_transform(points, mtx)
ValueError: Invalid vertices array.```